### PR TITLE
[FEAT] SSMを使った認証情報の管理を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,21 @@ ai-agent-hackathon/java_backend/.env
 
 ---
 
-## Google Cloud 認証ファイルの配置
+## Google Cloud 認証キーの確認
 
-Google Cloud Vertex AI を使用するために、サービスアカウントの認証ファイル（`key.json`）を以下のディレクトリに配置してください：
-
+google cloud cliのGoogle Account認証を行います。
+```sh
+gcloud config
 ```
-ai-agent-hackathon/java_backend/src/main/resources/key.json
+
+Google Cloud Secret Service Managerがロードされていることを確認します。
+
+```sh
+gcloud secrets list --project=ai-hackathon-460510
+
+NAME           CREATED              REPLICATION_POLICY  LOCATIONS
+firebase-key   2025-06-04T12:41:36  automatic           -
+vertex-ai-key  2025-06-04T13:07:33  automatic           -
 ```
 
 ---

--- a/java_backend/build.gradle
+++ b/java_backend/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'com.google.cloud:google-cloud-vertexai:1.8.0'
 	implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'com.google.cloud:google-cloud-secretmanager:2.33.0'
 }
 
 tasks.named('test') {

--- a/java_backend/src/main/java/com/example/config/FirebaseConfig.java
+++ b/java_backend/src/main/java/com/example/config/FirebaseConfig.java
@@ -3,44 +3,56 @@ package com.example.config;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.Firestore;
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.cloud.FirestoreClient;
-
-import io.github.cdimascio.dotenv.Dotenv;
+import com.google.protobuf.ByteString;
 
 @Configuration
 public class FirebaseConfig {
 
-    private final FirebaseApp firebaseApp;
+    @Value("${google.cloud.project-id}")
+    private String projectId;
 
-    public FirebaseConfig() throws IOException {
-        Dotenv dotenv = Dotenv.configure().load();
+    @Value("${google.cloud.firebase.secret-id}")
+    private String secretId; // 例: "firebase-key"
 
-        String credentialsJson = dotenv.get("FIREBASE_CREDENTIALS");
-        InputStream serviceAccount = new ByteArrayInputStream(credentialsJson.getBytes(StandardCharsets.UTF_8));
+    @Bean(name = "firebaseGoogleCredentials")
+    public GoogleCredentials googleCredentials() throws IOException {
+        try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+            SecretVersionName secretVersionName =
+                    SecretVersionName.of(projectId, secretId, "latest");
 
+            AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+            ByteString secretData = response.getPayload().getData();
+
+            try (InputStream keyStream = new ByteArrayInputStream(secretData.toByteArray())) {
+                return GoogleCredentials.fromStream(keyStream);
+            }
+        }
+    }
+
+    @Bean
+    public FirebaseApp firebaseApp(@Qualifier("firebaseGoogleCredentials") GoogleCredentials credentials) throws IOException {
         FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .setCredentials(credentials)
                 .build();
-
-        this.firebaseApp = FirebaseApp.initializeApp(options);
+        return FirebaseApp.initializeApp(options);
     }
 
     @Bean
-    public FirebaseApp firebaseApp() {
-        return firebaseApp;
-    }
-
-    @Bean
-    public Firestore firestore() {
+    public Firestore firestore(FirebaseApp firebaseApp) {
         return FirestoreClient.getFirestore(firebaseApp);
     }
 }

--- a/java_backend/src/main/java/com/example/service/RoadmapGenerationService.java
+++ b/java_backend/src/main/java/com/example/service/RoadmapGenerationService.java
@@ -1,21 +1,22 @@
 package com.example.service;
 
-import com.example.dto.RoadmapResponse;
-import com.example.dto.RoadmapResponse.*;
-import com.google.cloud.vertexai.api.GenerateContentResponse;
-import com.google.cloud.vertexai.generativeai.ContentMaker;
-import com.google.cloud.vertexai.generativeai.GenerativeModel;
-import org.json.JSONArray;
-import org.json.JSONObject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.example.dto.RoadmapResponse;
+import com.example.dto.RoadmapResponse.ArrowParams;
+import com.example.dto.RoadmapResponse.Connection;
+import com.example.dto.RoadmapResponse.Element;
+import com.example.dto.RoadmapResponse.GridBackgroundParams;
+import com.google.cloud.vertexai.api.GenerateContentResponse;
+import com.google.cloud.vertexai.generativeai.ContentMaker;
+import com.google.cloud.vertexai.generativeai.GenerativeModel;
 
 @Service
 public class RoadmapGenerationService {

--- a/java_backend/src/main/java/com/example/service/SimpleLLMService.java
+++ b/java_backend/src/main/java/com/example/service/SimpleLLMService.java
@@ -1,10 +1,11 @@
 package com.example.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.generativeai.ContentMaker;
 import com.google.cloud.vertexai.generativeai.GenerativeModel;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 @Service
 public class SimpleLLMService {

--- a/java_backend/src/main/resources/application.properties
+++ b/java_backend/src/main/resources/application.properties
@@ -5,3 +5,6 @@ google.cloud.project-id=ai-hackathon-460510
 google.cloud.location=europe-west3
 google.cloud.model=gemini-1.5-flash-002
 google.cloud.credentials.location=classpath:key.json
+google.cloud.vertexai.secret-id=vertex-ai-key
+google.cloud.firebase.secret-id=firebase-key
+spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
## やったこと

gcloud cliと SSMを使って、key.jsonがなくてもローカル開発・デプロイができるようになったはず...

## 確認して欲しいこと

- [ ]`gcloud config`で認証済みであること
- [ ] `gcloud config set project ai-hackathon-460510`でデフォルトのプロジェクトを設定
- [ ] `gcloud secrets list --project=ai-hackathon-460510`で認証情報の一覧を確認