### PR TITLE
feat: ノードを深掘りするAPIの作成

### DIFF
--- a/java_backend/src/main/java/com/example/dto/AddChildNodesRequest.java
+++ b/java_backend/src/main/java/com/example/dto/AddChildNodesRequest.java
@@ -1,0 +1,9 @@
+package com.example.dto;
+
+import lombok.Data;
+
+@Data
+public class AddChildNodesRequest {
+    private String mapId;
+    private String nodeId;
+}

--- a/java_backend/src/main/java/com/example/dto/AddChildNodesResponse.java
+++ b/java_backend/src/main/java/com/example/dto/AddChildNodesResponse.java
@@ -1,0 +1,11 @@
+package com.example.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class AddChildNodesResponse {
+    private String parentNodeId;
+    private List<Node> childNodes;
+    private String message;
+}

--- a/java_backend/src/main/java/com/example/service/ChildNodeGenerationService.java
+++ b/java_backend/src/main/java/com/example/service/ChildNodeGenerationService.java
@@ -1,0 +1,177 @@
+package com.example.service;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.dto.Node;
+
+@Service
+public class ChildNodeGenerationService {
+    private static final Logger logger = LoggerFactory.getLogger(ChildNodeGenerationService.class);
+    
+    private final SimpleLLMService llmService;
+    private final NodeService nodeService;
+    
+    @Autowired
+    public ChildNodeGenerationService(SimpleLLMService llmService, NodeService nodeService) {
+        this.llmService = llmService;
+        this.nodeService = nodeService;
+    }
+    
+    public List<Node> generateChildNodes(String mapId, Node parentNode) throws InterruptedException, ExecutionException {
+        logger.info("開始: 子ノード生成 (親ノード: {})", parentNode.getTitle());
+        
+        String llmResponse = requestChildTasksFromLLM(parentNode.getDescription());
+
+        List<Node> childNodes = createChildNodesFromLLMResponse(mapId, parentNode, llmResponse);
+
+        List<Node> savedChildNodes = nodeService.createNodes(childNodes);
+
+        updateParentNodeWithChildrenIds(parentNode, savedChildNodes);
+        
+        logger.info("子ノード生成完了 (生成件数: {})", savedChildNodes.size());
+        return savedChildNodes;
+    }
+    
+    private String requestChildTasksFromLLM(String description) {
+        String prompt = createChildTaskPrompt(description);
+        return llmService.askLLM(prompt);
+    }
+    
+    private String createChildTaskPrompt(String description) {
+        return String.format("""
+            以下のタスクを3-4個の具体的で実行可能な細かいサブタスクに分解してください。
+            
+            メインタスク: %s
+            
+            以下の要件に従ってサブタスクを作成してください：
+            1. 各サブタスクは具体的で実行可能な内容にする
+            2. メインタスクを達成するために必要な手順を順序立てて考える
+            3. 各サブタスクは1-3時間程度で完了できる規模にする
+            4. 学習や作業の流れを考慮した論理的な順序にする
+            
+            回答は以下の形式で出力してください：
+            1. [サブタスク1のタイトル] - [サブタスク1の説明]
+            2. [サブタスク2のタイトル] - [サブタスク2の説明]
+            3. [サブタスク3のタイトル] - [サブタスク3の説明]
+            4. [サブタスク4のタイトル] - [サブタスク4の説明]（必要に応じて）
+            
+            例:
+            1. HTMLファイルの作成 - 基本的なHTML構造を持つindex.htmlファイルを作成する
+            2. スタイルシートの準備 - CSSファイルを作成し、HTMLにリンクする
+            """, description);
+    }
+    
+    private List<Node> createChildNodesFromLLMResponse(String mapId, Node parentNode, String llmResponse) {
+        List<Node> childNodes = new ArrayList<>();
+        
+        List<ChildTask> childTasks = parseChildTasksFromResponse(llmResponse);
+        
+        Date now = new Date();
+        
+        for (int i = 0; i < childTasks.size(); i++) {
+            ChildTask task = childTasks.get(i);
+            
+            Node childNode = new Node();
+            childNode.setMap_id(mapId);
+            childNode.setTitle(task.getTitle());
+            childNode.setDescription(task.getDescription());
+            childNode.setNode_type("Task");
+            childNode.setDuration(2);
+            childNode.setProgress_rate(0);
+            childNode.setParent_id(parentNode.getId());
+            childNode.setChildren_ids(new ArrayList<>());
+            
+            if (parentNode.getDue_at() != null) {
+                long parentDueTime = parentNode.getDue_at().getTime();
+                long currentTime = now.getTime();
+                long timeRange = parentDueTime - currentTime;
+                long childDueTime = currentTime + (timeRange * (i + 1) / childTasks.size());
+                childNode.setDue_at(new Date(childDueTime));
+            }
+            
+            childNodes.add(childNode);
+        }
+        
+        return childNodes;
+    }
+    
+    private List<ChildTask> parseChildTasksFromResponse(String response) {
+        List<ChildTask> tasks = new ArrayList<>();
+        
+        String[] lines = response.split("\n");
+        
+        for (String line : lines) {
+            line = line.trim();
+            if (line.matches("^\\d+\\..*")) {
+                String content = line.substring(line.indexOf('.') + 1).trim();
+                
+                String title;
+                String description;
+                
+                if (content.contains(" - ")) {
+                    String[] parts = content.split(" - ", 2);
+                    title = parts[0].trim();
+                    description = parts[1].trim();
+                } else {
+                    title = content;
+                    description = content;
+                }
+                
+                tasks.add(new ChildTask(title, description));
+            }
+        }
+        
+        if (tasks.isEmpty()) {
+            tasks.add(new ChildTask("詳細検討", "詳細な検討と実装を行う"));
+            tasks.add(new ChildTask("実装作業", "具体的な実装作業を進める"));
+            tasks.add(new ChildTask("テスト・確認", "動作テストと品質確認を行う"));
+        }
+        
+        return tasks;
+    }
+    
+    private void updateParentNodeWithChildrenIds(Node parentNode, List<Node> childNodes) 
+            throws InterruptedException, ExecutionException {
+        
+        List<String> childrenIds = new ArrayList<>();
+        for (Node child : childNodes) {
+            childrenIds.add(child.getId());
+        }
+        
+        // 既存の子ノードIDがある場合は追加
+        if (parentNode.getChildren_ids() != null) {
+            childrenIds.addAll(parentNode.getChildren_ids());
+        }
+        
+        parentNode.setChildren_ids(childrenIds);
+        nodeService.updateNode(parentNode);
+        
+        logger.info("親ノードの children_ids 更新完了: {}", parentNode.getId());
+    }
+    
+    private static class ChildTask {
+        private final String title;
+        private final String description;
+        
+        public ChildTask(String title, String description) {
+            this.title = title;
+            this.description = description;
+        }
+        
+        public String getTitle() {
+            return title;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+    }
+}

--- a/java_backend/src/main/java/com/example/service/NodeService.java
+++ b/java_backend/src/main/java/com/example/service/NodeService.java
@@ -1,0 +1,113 @@
+package com.example.service;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.dto.Node;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.WriteResult;
+
+@Service
+public class NodeService {
+    private static final Logger logger = LoggerFactory.getLogger(NodeService.class);
+    
+    private final Firestore firestore;
+    private static final String NODES_COLLECTION = "nodes";
+    
+    @Autowired
+    public NodeService(Firestore firestore) {
+        this.firestore = firestore;
+        logger.info("NodeService initialized with Firestore instance");
+    }
+    
+    public Node getNodeById(String nodeId) throws InterruptedException, ExecutionException {
+        logger.info("開始: ノード取得 (ID: {})", nodeId);
+        
+        DocumentReference docRef = firestore.collection(NODES_COLLECTION).document(nodeId);
+        ApiFuture<DocumentSnapshot> future = docRef.get();
+        DocumentSnapshot document = future.get();
+        
+        if (document.exists()) {
+            Node node = document.toObject(Node.class);
+            logger.info("ノード取得完了: ID={}, Title={}", node.getId(), node.getTitle());
+            return node;
+        } else {
+            logger.warn("ノードが見つかりませんでした: ID={}", nodeId);
+            return null;
+        }
+    }
+    
+    public Node createNode(Node node) throws InterruptedException, ExecutionException {
+        logger.info("開始: ノード作成 (Title: {})", node.getTitle());
+        
+        if (node.getId() == null || node.getId().isEmpty()) {
+            if (node.getParent_id() != null && !node.getParent_id().isEmpty()) {
+                int childCount = getChildCountForParent(node.getParent_id());
+                node.setId(node.getParent_id() + "-" + (childCount + 1));
+            } else {
+                node.setId("node-" + UUID.randomUUID().toString().substring(0, 8));
+            }
+        }
+
+        Date now = new Date();
+        node.setCreated_at(now);
+        node.setUpdated_at(now);
+        
+        DocumentReference docRef = firestore.collection(NODES_COLLECTION).document(node.getId());
+        ApiFuture<WriteResult> future = docRef.set(node);
+        WriteResult result = future.get();
+        
+        logger.info("ノード作成完了: ID={}, Title={}, 作成時刻={}", 
+                   node.getId(), node.getTitle(), result.getUpdateTime());
+        
+        return node;
+    }
+    
+    public Node updateNode(Node node) throws InterruptedException, ExecutionException {
+        logger.info("開始: ノード更新 (ID: {})", node.getId());
+        
+        node.setUpdated_at(new Date());
+
+        DocumentReference docRef = firestore.collection(NODES_COLLECTION).document(node.getId());
+        ApiFuture<WriteResult> future = docRef.set(node);
+        WriteResult result = future.get();
+        
+        logger.info("ノード更新完了: ID={}, 更新時刻={}", node.getId(), result.getUpdateTime());
+        
+        return node;
+    }
+    
+    public List<Node> createNodes(List<Node> nodes) throws InterruptedException, ExecutionException {
+        logger.info("開始: 複数ノード一括作成 (件数: {})", nodes.size());
+        
+        List<Node> createdNodes = new ArrayList<>();
+        
+        for (Node node : nodes) {
+            Node createdNode = createNode(node);
+            createdNodes.add(createdNode);
+        }
+        
+        logger.info("複数ノード一括作成完了 (作成件数: {})", createdNodes.size());
+        return createdNodes;
+    }
+    
+    private int getChildCountForParent(String parentId) throws InterruptedException, ExecutionException {
+        CollectionReference nodesCollection = firestore.collection(NODES_COLLECTION);
+        ApiFuture<QuerySnapshot> future = nodesCollection.whereEqualTo("parent_id", parentId).get();
+        QuerySnapshot querySnapshot = future.get();
+        return querySnapshot.getDocuments().size();
+    }
+}


### PR DESCRIPTION
指定したmapId, nodeIdから対象のnode情報を取得して，そのディスクリプションをもとに子ノードを作成するAPIを作成しました

確認して欲しいところ
- [x] /api/roadmap/add-child-nodes (POST) が[Swagger UI](http://localhost:8080/swagger-ui/index.html)に表示される
- [x] リクエストボディに [mapId]と [nodeId]フィールドが正しく定義されている
- [x] 既存の親ノード（例：node-0001）に対して子ノード生成が成功する
- [x] 子ノードのIDが {親ノードID}-{連番} 形式で生成される（例：node-0001-1, node-0001-2）
- [x] 生成された子ノードがFirestoreのnodesコレクションに保存される
- [x] 各子ノードに適切なメタデータ（作成日時、期限等）が設定される
- [x] 親ノードの children_ids 配列に新しい子ノードのIDが追加される
- [x] 子ノードの parent_id が正しく設定される
- [ ] プロンプト確認して欲しいです！！現在サブタスクは1-3時間程度で設定してます（これはのちに期限に合わせた方がいいかも．．．）
 