### PR TITLE
開発環境用の認証設定を追加

### DIFF
--- a/java_backend/src/main/java/com/example/config/VertexAIConfig.java
+++ b/java_backend/src/main/java/com/example/config/VertexAIConfig.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+q
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
@@ -32,18 +32,28 @@ public class VertexAIConfig {
     @Value("${google.cloud.vertexai.secret-id}")
     private String secretId;  // 例: "verex-ai-key"
 
+    @Value("${google.cloud.auth.type:secret-manager}")
+    private String authType;
+
     @Bean(name = "vertexAIGoogleCredentials")
     public GoogleCredentials googleCredentials() throws IOException {
-        try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
-            SecretVersionName secretVersionName =
-                    SecretVersionName.of(projectId, secretId, "latest");
+        if ("adc".equals(authType)) {
+            // 開発環境では Application Default Credentials を使用
+            return GoogleCredentials.getApplicationDefault()
+                    .createScoped("https://www.googleapis.com/auth/cloud-platform");
+        } else {
+            // 本番環境では Secret Manager を使用
+            try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+                SecretVersionName secretVersionName =
+                        SecretVersionName.of(projectId, secretId, "latest");
 
-            AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
-            ByteString secretData = response.getPayload().getData();
+                AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+                ByteString secretData = response.getPayload().getData();
 
-            try (InputStream keyStream = new ByteArrayInputStream(secretData.toByteArray())) {
-                return GoogleCredentials.fromStream(keyStream)
-                        .createScoped("https://www.googleapis.com/auth/cloud-platform");
+                try (InputStream keyStream = new ByteArrayInputStream(secretData.toByteArray())) {
+                    return GoogleCredentials.fromStream(keyStream)
+                            .createScoped("https://www.googleapis.com/auth/cloud-platform");
+                }
             }
         }
     }

--- a/java_backend/src/main/resources/application-dev.properties
+++ b/java_backend/src/main/resources/application-dev.properties
@@ -1,0 +1,12 @@
+# 開発環境用設定
+spring.application.name=ai-hackathon-dev
+
+# 開発環境では Application Default Credentials を使用
+google.cloud.auth.type=adc
+
+# 開発用ログレベル
+logging.level.com.example=DEBUG
+logging.level.org.springframework.web=DEBUG
+
+# 開発ツール有効
+spring.devtools.restart.enabled=true

--- a/java_backend/src/main/resources/application-prod.properties
+++ b/java_backend/src/main/resources/application-prod.properties
@@ -1,0 +1,15 @@
+# 本番環境用設定
+spring.application.name=ai-hackathon-prod
+
+# 本番環境では Secret Manager を使用
+google.cloud.auth.type=secret-manager
+
+# 本番用ログレベル
+logging.level.root=WARN
+logging.level.com.example=INFO
+
+# 本番環境では開発ツール無効
+spring.devtools.restart.enabled=false
+
+# Swagger UI を本番では無効化
+springdoc.swagger-ui.enabled=false


### PR DESCRIPTION
## 開発環境と本番環境の認証設定を分離

### 変更内容
開発環境と本番環境で異なる認証方式を使用できるように環境を分離

- **開発環境**: Application Default Credentials（簡単）
- **本番環境**: Secret Manager（セキュア、従来通り）

### 開発環境の使用方法
```bash
gcloud auth application-default login
./gradlew bootRun --args="--spring.profiles.active=dev"
```

### 本番環境の使用方法
```bash
./gradlew bootRun --args="--spring.profiles.active=prod"