### PR TITLE
feat(dto): 新規ロードマップ生成フローのデータモデルとDTOを定義

### DIFF
--- a/java_backend/src/main/java/com/example/dto/AnswerDto.java
+++ b/java_backend/src/main/java/com/example/dto/AnswerDto.java
@@ -1,0 +1,18 @@
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+/**
+ * ユーザーからの一つの回答の構造を表します。
+ */
+@Data
+@NoArgsConstructor
+public class AnswerDto {
+    @JsonProperty("question_id")
+    private String questionId;
+    // テキスト、単一選択、複数選択の全てをList<String>で統一的に扱います
+    private List<String> value;
+}

--- a/java_backend/src/main/java/com/example/dto/CreateQuestionsRequest.java
+++ b/java_backend/src/main/java/com/example/dto/CreateQuestionsRequest.java
@@ -1,0 +1,13 @@
+package com.example.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 質問生成API (/questions) へのリクエストボディを表します。
+ */
+@Data
+@NoArgsConstructor
+public class CreateQuestionsRequest {
+    private String goal;
+}

--- a/java_backend/src/main/java/com/example/dto/CreateQuestionsResponse.java
+++ b/java_backend/src/main/java/com/example/dto/CreateQuestionsResponse.java
@@ -1,0 +1,16 @@
+package com.example.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+/**
+ * 質問生成API (/questions) のレスポンスボディを表します。
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateQuestionsResponse {
+    private List<QuestionDto> questions;
+}

--- a/java_backend/src/main/java/com/example/dto/CreateRoadmapRequest.java
+++ b/java_backend/src/main/java/com/example/dto/CreateRoadmapRequest.java
@@ -1,0 +1,17 @@
+package com.example.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+/**
+ * ロードマップ本体生成API (/roadmaps) へのリクエストボディを表します。
+ * 新しいフローに必要な全てのコンテキスト情報を含みます。
+ */
+@Data
+@NoArgsConstructor
+public class CreateRoadmapRequest {
+    private String goal;
+    private List<AnswerDto> answers;
+    private int totalEstimatedHours;
+}

--- a/java_backend/src/main/java/com/example/dto/EstimateHoursRequest.java
+++ b/java_backend/src/main/java/com/example/dto/EstimateHoursRequest.java
@@ -1,0 +1,15 @@
+package com.example.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+/**
+ * 必要時間算出API (/estimations) へのリクエストボディを表します。
+ */
+@Data
+@NoArgsConstructor
+public class EstimateHoursRequest {
+    private String goal;
+    private List<AnswerDto> answers;
+}

--- a/java_backend/src/main/java/com/example/dto/EstimateHoursResponse.java
+++ b/java_backend/src/main/java/com/example/dto/EstimateHoursResponse.java
@@ -1,0 +1,15 @@
+package com.example.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 必要時間算出API (/estimations) のレスポンスボディを表します。
+ */
+@Data
+@NoArgsConstructor
+public class EstimateHoursResponse {
+    private int minHours;
+    private int maxHours;
+    private String comment;
+}

--- a/java_backend/src/main/java/com/example/dto/QuestionDto.java
+++ b/java_backend/src/main/java/com/example/dto/QuestionDto.java
@@ -1,0 +1,32 @@
+package com.example.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+/**
+ * 質問データ転送オブジェクト
+ * 
+ * このクラスは、質問のID、テキスト、タイプ、および選択肢のリストを表します。
+ * JSONシリアライズ/デシリアライズのためにJacksonアノテーションを使用しています。
+ */
+
+ 
+/**
+ * typeフィールドの値は以下のいずれかです:
+ * - "text": テキスト入力
+ * - "single_choice": 単一選択肢
+ * - "multiple_choice": 複数選択肢
+ *  single_choice, multiple_choiceの場合は、optionsフィールドにその選択肢のリストが含まれます。
+ */
+
+@Data
+@NoArgsConstructor
+public class QuestionDto {
+    @JsonProperty("question_id")
+    private String questionId;
+    private String text;
+    private String type;
+    private List<String> options;
+}

--- a/java_backend/src/main/java/com/example/dto/RoadmapDocument.java
+++ b/java_backend/src/main/java/com/example/dto/RoadmapDocument.java
@@ -1,0 +1,36 @@
+package com.example.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Firestoreの 'roadmaps' コレクションに保存されるドキュメント全体を表すデータモデル。
+ */
+@Data
+@NoArgsConstructor
+public class RoadmapDocument {
+
+    // --- メタデータ ---
+    private String id; // FirestoreのドキュメントID (例: map-xxxx)
+    private String userId;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    // --- ロードマップ生成時のインプット情報 ---
+    private String goal;
+    private int totalEstimatedHours;
+    private CreationContext creationContext;
+
+    // --- 生成されたロードマップ本体---
+    private List<Node> nodes;
+
+    @Data
+    @NoArgsConstructor
+    public static class CreationContext {
+        // 将来の参照のために持たせる
+        private List<QuestionDto> questions;
+        private List<AnswerDto> answers;
+    }
+}

--- a/java_backend/src/main/java/com/example/service/RoadmapDocumentService.java
+++ b/java_backend/src/main/java/com/example/service/RoadmapDocumentService.java
@@ -1,0 +1,76 @@
+package com.example.service;
+
+import com.example.dto.RoadmapDocument;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.WriteResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * 新しいデータ構造であるRoadmapDocumentの永続化（Firestoreへの保存・取得など）を管理するサービス。
+ */
+@Service
+public class RoadmapDocumentService {
+
+    private static final Logger logger = LoggerFactory.getLogger(RoadmapDocumentService.class);
+    private final Firestore firestore;
+
+    private static final String ROADMAPS_COLLECTION = "roadmaps";
+
+    public RoadmapDocumentService(Firestore firestore) {
+        this.firestore = firestore;
+    }
+
+    /**
+     * RoadmapDocument全体をFirestoreに保存または上書きするメソッド。
+     * @param roadmapDocument 保存する完全なロードマップオブジェクト
+     * @return 保存されたRoadmapDocumentオブジェクト
+     */
+    public RoadmapDocument save(RoadmapDocument roadmapDocument) throws ExecutionException, InterruptedException {
+        String documentId = roadmapDocument.getId();
+        if (documentId == null || documentId.isEmpty()) {
+            throw new IllegalArgumentException("RoadmapDocument must have a non-empty ID.");
+        }
+        
+        logger.info("開始: RoadmapDocumentの保存 (ID: {})", documentId);
+
+        DocumentReference docRef = firestore.collection(ROADMAPS_COLLECTION).document(documentId);
+        
+        ApiFuture<WriteResult> future = docRef.set(roadmapDocument);
+        
+        WriteResult result = future.get();
+        logger.info("完了: RoadmapDocumentの保存 (ID: {}), 更新時刻={}", documentId, result.getUpdateTime());
+        
+        return roadmapDocument;
+    }
+
+    /**
+     * IDを指定して、単一のRoadmapDocumentをFirestoreから取得するメソッド。
+     * @param roadmapId 取得したいロードマップのID
+     * @return 見つかったRoadmapDocumentオブジェクト。存在しない場合はnullを返す。
+     */
+    public RoadmapDocument findById(String roadmapId) throws ExecutionException, InterruptedException {
+        logger.info("開始: RoadmapDocumentの取得 (ID: {})", roadmapId);
+        
+        DocumentReference docRef = firestore.collection(ROADMAPS_COLLECTION).document(roadmapId);
+        ApiFuture<DocumentSnapshot> future = docRef.get();
+        DocumentSnapshot document = future.get();
+
+        if (document.exists()) {
+            RoadmapDocument roadmap = document.toObject(RoadmapDocument.class);
+            logger.info("完了: RoadmapDocumentの取得成功 (ID: {})", roadmapId);
+            return roadmap;
+        } else {
+            logger.warn("ドキュメントが見つかりませんでした: {}", roadmapId);
+            return null;
+        }
+    }
+
+    // 将来的には、更新(update)や削除(delete)のメソッドもここに追加していく
+}

--- a/java_backend/src/test/java/com/example/service/RoadmapDocumentServiceTest.java
+++ b/java_backend/src/test/java/com/example/service/RoadmapDocumentServiceTest.java
@@ -1,0 +1,137 @@
+package com.example.service;
+
+import com.example.dto.RoadmapDocument;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.WriteResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.lenient;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class) // JUnit5でMockitoを有効にするためのアノテーション
+class RoadmapDocumentServiceTest {
+
+    // --- モック（偽物）の準備 ---
+    @Mock // Firestoreの偽物を作成
+    private Firestore firestore;
+
+    @Mock // Firestore SDKが内部で使うオブジェクトも、偽物を用意する必要がある
+    private CollectionReference collectionReference;
+    @Mock
+    private DocumentReference documentReference;
+    @Mock
+    private ApiFuture<DocumentSnapshot> apiFuture;
+    @Mock
+    private DocumentSnapshot documentSnapshot;
+    @Mock
+    private ApiFuture<WriteResult> writeApiFuture;
+    @Mock
+    private WriteResult writeResult;
+
+    // --- テスト対象のクラス ---
+    @InjectMocks // @Mockのアノテーションが付いた偽物たちを、このクラスに自動で注入してくれる
+    private RoadmapDocumentService roadmapDocumentService;
+
+    // 各テストが実行される前に、このメソッドが一度呼ばれる
+    @BeforeEach
+    void setUp() {
+        // モックの振る舞いを定義する
+        // firestore.collection(anyString()) が呼ばれたら、偽物のcollectionReferenceを返すように設定
+        lenient().when(firestore.collection(anyString())).thenReturn(collectionReference);
+        lenient().when(collectionReference.document(anyString())).thenReturn(documentReference);
+    }
+
+    // --- テストケース ---
+
+    @Test
+    void findById_ドキュメントが存在する場合_RoadmapDocumentを返す() throws ExecutionException, InterruptedException {
+        // --- Given (前提条件の設定) ---
+        String roadmapId = "test-map-123";
+        RoadmapDocument expectedDocument = new RoadmapDocument();
+        expectedDocument.setId(roadmapId);
+        expectedDocument.setGoal("テストゴール");
+
+        // documentReference.get() が呼ばれたら...というように、メソッド呼び出しの連鎖を定義していく
+        when(documentReference.get()).thenReturn(apiFuture);
+        when(apiFuture.get()).thenReturn(documentSnapshot);
+        when(documentSnapshot.exists()).thenReturn(true); // ドキュメントは「存在する」フリをする
+        when(documentSnapshot.toObject(RoadmapDocument.class)).thenReturn(expectedDocument); // toObjectが呼ばれたら、用意した偽のデータを返す
+
+        // --- When (テスト対象メソッドの実行) ---
+        RoadmapDocument actualDocument = roadmapDocumentService.findById(roadmapId);
+
+        // --- Then (結果の検証) ---
+        assertThat(actualDocument).isNotNull(); // 結果がnullでないこと
+        assertThat(actualDocument.getId()).isEqualTo(roadmapId); // IDが一致すること
+        assertThat(actualDocument.getGoal()).isEqualTo("テストゴール"); // 中身が正しいこと
+
+        // サービスが正しいコレクションとドキュメントIDを呼び出したか検証
+        verify(firestore).collection("roadmaps");
+        verify(collectionReference).document(roadmapId);
+    }
+
+    @Test
+    void findById_ドキュメントが存在しない場合_nullを返す() throws ExecutionException, InterruptedException {
+        // --- Given (前提条件の設定) ---
+        String roadmapId = "not-found-id";
+        when(documentReference.get()).thenReturn(apiFuture);
+        when(apiFuture.get()).thenReturn(documentSnapshot);
+        when(documentSnapshot.exists()).thenReturn(false); // ドキュメントは「存在しない」フリをする
+
+        // --- When (テスト対象メソッドの実行) ---
+        RoadmapDocument actualDocument = roadmapDocumentService.findById(roadmapId);
+
+        // --- Then (結果の検証) ---
+        assertThat(actualDocument).isNull(); // 結果がnullであること
+    }
+
+    @Test
+    void save_正常なRoadmapDocumentを渡すと_成功する() throws ExecutionException, InterruptedException {
+        // --- Given (前提条件の設定) ---
+        RoadmapDocument documentToSave = new RoadmapDocument();
+        documentToSave.setId("new-map-456");
+        documentToSave.setGoal("保存テスト");
+
+        // documentReference.set(...) が呼ばれたときの振る舞いを定義
+        when(documentReference.set(any(RoadmapDocument.class))).thenReturn(writeApiFuture);
+        when(writeApiFuture.get()).thenReturn(writeResult);
+
+        // --- When (テスト対象メソッドの実行) ---
+        RoadmapDocument savedDocument = roadmapDocumentService.save(documentToSave);
+
+        // --- Then (結果の検証) ---
+        assertThat(savedDocument).isNotNull();
+        assertThat(savedDocument.getId()).isEqualTo("new-map-456");
+
+        // documentReference.set()が、正しいオブジェクトを引数にして呼び出されたか検証
+        verify(documentReference).set(documentToSave);
+    }
+    
+    @Test
+    void save_IDがnullの場合_IllegalArgumentExceptionをスローする() {
+        // --- Given (前提条件の設定) ---
+        RoadmapDocument documentWithoutId = new RoadmapDocument(); // IDがnull
+
+        // --- When & Then (実行と例外の検証) ---
+        // saveメソッドを実行すると、IllegalArgumentExceptionが投げられることを表明する
+        assertThrows(IllegalArgumentException.class, () -> {
+            roadmapDocumentService.save(documentWithoutId);
+        });
+    }
+}


### PR DESCRIPTION
新しい3段階APIフロー（質問→見積もり→生成）で使用する全てのデータ転送オブジェクト（DTO）と、Firestoreに保存する新しいデータモデル（RoadmapDocument）のJavaクラスを作成する。
このタスクでは、既存コードの変更は行わず、新規ファイルの追加のみを行う。

完了の定義 (Definition of Done):

CreateQuestionsRequest/Response, QuestionDtoが作成されていること。
EstimateHoursRequest/Response, AnswerDtoが作成されていること。
CreateRoadmapRequestが作成されていること。
RoadmapDocument.javaとそのネストクラスが定義されていること。
プロジェクトがエラーなくコンパイルできること。
データベースの構造に問題がないこと

Closes #31.

実装内容 (Implementation)
service/RoadmapDocumentService.java を新規作成
save(RoadmapDocument doc): ドキュメント全体をアトミックに保存/上書きするメソッドを実装。
findById(String id): IDを基にドキュメント全体を一件取得するメソッドを実装。
service/RoadmapDocumentServiceTest.java を新規作成
Mockitoを利用してFirestoreをモック化。
saveとfindByIdメソッドの正常系・異常系に対するユニットテストを実装。

検証方法 (How to Verify)
以下のコマンドを実行し、追加したユニットテストがすべて成功することを確認してください。
./gradlew test --tests "com.example.service.RoadmapDocumentServiceTest"
可能であれば、java_backend/src/test/java/com/example/service/RoadmapDocumentServiceTest.javaのテストコードも確認していただけると助かります。
また、java_backend/src/main/java/com/example/service/RoadmapDocumentService.javaのロジックに問題がなさそうか確認していただけると助かります。

Closes #32.